### PR TITLE
refactor(BBD-799): Simplify tag selectors

### DIFF
--- a/src/autocomplete/index.ts
+++ b/src/autocomplete/index.ts
@@ -16,11 +16,10 @@ class Autocomplete {
   };
 
   constructor() {
-    const state = this.flux.store.getState();
-    const suggestions = Selectors.autocompleteSuggestions(state);
-    const category = Selectors.autocompleteCategoryField(state);
-    const categoryValues = Selectors.autocompleteCategoryValues(state);
-    const navigations = Selectors.autocompleteNavigations(state);
+    const suggestions = this.select(Selectors.autocompleteSuggestions);
+    const category = this.select(Selectors.autocompleteCategoryField);
+    const categoryValues = this.select(Selectors.autocompleteCategoryValues);
+    const navigations = this.select(Selectors.autocompleteNavigations);
     this.state = { ...this.state, suggestions, navigations, category, categoryValues, selected: -1 };
   }
 
@@ -87,7 +86,7 @@ class Autocomplete {
   }
 
   updateProducts({ dataset: { query: selectedQuery, refinement, field } }: HTMLElement) {
-    const query = selectedQuery == null ? Selectors.autocompleteQuery(this.flux.store.getState()) : selectedQuery;
+    const query = selectedQuery == null ? this.select(Selectors.autocompleteQuery) : selectedQuery;
     this.flux.emit('query:update', query);
     // tslint:disable-next-line max-line-length
     this.flux.saytProducts(field ? null : query, refinement ? [{ field: field || this.state.category, value: refinement }] : []);

--- a/src/categories/index.ts
+++ b/src/categories/index.ts
@@ -11,13 +11,13 @@ class Categories {
     onClick: ({ matchAll, value }) => () =>
       this.actions.updateSearch({
         clear: true,
-        query: Selectors.autocompleteQuery(this.flux.store.getState()),
+        query: this.select(Selectors.autocompleteQuery),
         ...(<any>matchAll || {
           navigationId: this.$autocomplete.category,
           value
         })
       }),
-    query: Selectors.autocompleteQuery(this.flux.store.getState())
+    query: this.select(Selectors.autocompleteQuery)
   };
 
   init() {

--- a/src/sayt/index.ts
+++ b/src/sayt/index.ts
@@ -17,7 +17,7 @@ class Sayt {
     showRecommendations: false,
     showProducts: true,
     highlight: (value, replacement) => {
-      const query = Selectors.autocompleteQuery(this.flux.store.getState());
+      const query = this.select(Selectors.autocompleteQuery);
       return value.replace(new RegExp(escapeRegexp(query), 'i'), replacement);
     }
   };
@@ -44,7 +44,7 @@ class Sayt {
     this.unregisterClickAwayHandler();
     if (this.state.isActive) {
       this.set({ isActive: false });
-      this.flux.emit('query:update', Selectors.query(this.flux.store.getState()));
+      this.flux.emit('query:update', this.select(Selectors.query));
     }
   }
 

--- a/test/unit/autocomplete.ts
+++ b/test/unit/autocomplete.ts
@@ -14,10 +14,6 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
 
   beforeEach(() => {
     Autocomplete.prototype.flux = <any>{};
-    // autocompleteSuggestionsSelector = stub(Selectors, 'autocompleteSuggestions').returns(SUGGESTIONS);
-    // autocompleteCategoryFieldSelector = stub(Selectors, 'autocompleteCategoryField').returns(CATEGORY);
-    // autocompleteCategoryValuesSelector = stub(Selectors, 'autocompleteCategoryValues').returns(CATEGORY_VALUES);
-    // autocompleteNavigationsSelector = stub(Selectors, 'autocompleteNavigations').returns(NAVIGATIONS);
     Autocomplete.prototype.select = spy((selector) => {
       if (selector === Selectors.autocompleteSuggestions) {
         return SUGGESTIONS;
@@ -34,7 +30,10 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
     });
     autocomplete = new Autocomplete();
   });
-  afterEach(() => delete Autocomplete.prototype.flux);
+  afterEach(() => {
+    delete Autocomplete.prototype.flux;
+    delete Autocomplete.prototype.select;
+  });
 
   describe('constructor()', () => {
     describe('state', () => {

--- a/test/unit/autocomplete.ts
+++ b/test/unit/autocomplete.ts
@@ -3,25 +3,35 @@ import * as sinon from 'sinon';
 import Autocomplete from '../../src/autocomplete';
 import suite from './_suite';
 
-const CATEOGORY = 'brand';
-const CATEOGORY_VALUES = ['a', 'b', 'c'];
+const CATEGORY = 'brand';
+const CATEGORY_VALUES = ['a', 'b', 'c'];
 const SUGGESTIONS = ['d', 'e', 'f'];
 const NAVIGATIONS = ['g', 'h', 'i'];
-const STATE = { h: 'j' };
 
 suite('Autocomplete', ({ expect, spy, stub }) => {
   let autocomplete: Autocomplete;
-  let autocompleteSuggestionsSelector: sinon.SinonStub;
-  let autocompleteCategoryFieldSelector: sinon.SinonStub;
-  let autocompleteCategoryValuesSelector: sinon.SinonStub;
-  let autocompleteNavigationsSelector: sinon.SinonStub;
+  let select: sinon.SinonSpy;
 
   beforeEach(() => {
-    Autocomplete.prototype.flux = <any>{ store: { getState: () => STATE } };
-    autocompleteSuggestionsSelector = stub(Selectors, 'autocompleteSuggestions').returns(SUGGESTIONS);
-    autocompleteCategoryFieldSelector = stub(Selectors, 'autocompleteCategoryField').returns(CATEOGORY);
-    autocompleteCategoryValuesSelector = stub(Selectors, 'autocompleteCategoryValues').returns(CATEOGORY_VALUES);
-    autocompleteNavigationsSelector = stub(Selectors, 'autocompleteNavigations').returns(NAVIGATIONS);
+    Autocomplete.prototype.flux = <any>{};
+    // autocompleteSuggestionsSelector = stub(Selectors, 'autocompleteSuggestions').returns(SUGGESTIONS);
+    // autocompleteCategoryFieldSelector = stub(Selectors, 'autocompleteCategoryField').returns(CATEGORY);
+    // autocompleteCategoryValuesSelector = stub(Selectors, 'autocompleteCategoryValues').returns(CATEGORY_VALUES);
+    // autocompleteNavigationsSelector = stub(Selectors, 'autocompleteNavigations').returns(NAVIGATIONS);
+    Autocomplete.prototype.select = spy((selector) => {
+      if (selector === Selectors.autocompleteSuggestions) {
+        return SUGGESTIONS;
+      }
+      if (selector === Selectors.autocompleteCategoryField) {
+        return CATEGORY;
+      }
+      if (selector === Selectors.autocompleteCategoryValues) {
+        return CATEGORY_VALUES;
+      }
+      if (selector === Selectors.autocompleteNavigations) {
+        return NAVIGATIONS;
+      }
+    });
     autocomplete = new Autocomplete();
   });
   afterEach(() => delete Autocomplete.prototype.flux);
@@ -32,8 +42,8 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
         expect(autocomplete.state).to.eql({
           onHover: autocomplete.state.onHover,
           selected: -1,
-          category: CATEOGORY,
-          categoryValues: CATEOGORY_VALUES,
+          category: CATEGORY,
+          categoryValues: CATEGORY_VALUES,
           suggestions: SUGGESTIONS,
           navigations: NAVIGATIONS
         });
@@ -294,13 +304,13 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
     it('should call flux.saytProducts() with original query', () => {
       const saytProducts = spy();
       const state = { a: 'b' };
-      const querySelector = stub(Selectors, 'autocompleteQuery').returns(query);
-      autocomplete.flux = <any>{ emit: () => null, saytProducts, store: { getState: () => state } };
+      select = Autocomplete.prototype.select = spy(() => query);
+      autocomplete.flux = <any>{ emit: () => null, saytProducts};
 
       autocomplete.updateProducts(<any>{ dataset: {} });
 
       expect(saytProducts).to.be.calledWithExactly(query, []);
-      expect(querySelector).to.be.calledWith(state);
+      expect(select).to.be.calledWith(Selectors.autocompleteQuery);
     });
 
     it('should call flux.saytProducts() with only refinement', () => {

--- a/test/unit/autocomplete.ts
+++ b/test/unit/autocomplete.ts
@@ -10,24 +10,15 @@ const NAVIGATIONS = ['g', 'h', 'i'];
 
 suite('Autocomplete', ({ expect, spy, stub }) => {
   let autocomplete: Autocomplete;
-  let select: sinon.SinonSpy;
+  let select: sinon.SinonStub;
 
   beforeEach(() => {
     Autocomplete.prototype.flux = <any>{};
-    Autocomplete.prototype.select = spy((selector) => {
-      if (selector === Selectors.autocompleteSuggestions) {
-        return SUGGESTIONS;
-      }
-      if (selector === Selectors.autocompleteCategoryField) {
-        return CATEGORY;
-      }
-      if (selector === Selectors.autocompleteCategoryValues) {
-        return CATEGORY_VALUES;
-      }
-      if (selector === Selectors.autocompleteNavigations) {
-        return NAVIGATIONS;
-      }
-    });
+    select = Autocomplete.prototype.select = stub();
+    select.withArgs(Selectors.autocompleteSuggestions).returns(SUGGESTIONS);
+    select.withArgs(Selectors.autocompleteCategoryField).returns(CATEGORY);
+    select.withArgs(Selectors.autocompleteCategoryValues).returns(CATEGORY_VALUES);
+    select.withArgs(Selectors.autocompleteNavigations).returns(NAVIGATIONS);
     autocomplete = new Autocomplete();
   });
   afterEach(() => {
@@ -303,7 +294,7 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
     it('should call flux.saytProducts() with original query', () => {
       const saytProducts = spy();
       const state = { a: 'b' };
-      select = Autocomplete.prototype.select = spy(() => query);
+      select.returns(query);
       autocomplete.flux = <any>{ emit: () => null, saytProducts};
 
       autocomplete.updateProducts(<any>{ dataset: {} });

--- a/test/unit/categories.ts
+++ b/test/unit/categories.ts
@@ -7,13 +7,12 @@ const QUERY = 'red dress';
 
 suite('Categories', ({ expect, spy, stub }) => {
   let categories: Categories;
-  let getState: sinon.SinonSpy;
-  let selectAutocompleteQuery: sinon.SinonStub;
+  let select: sinon.SinonSpy;
 
   beforeEach(() => {
-    selectAutocompleteQuery = stub(Selectors, 'autocompleteQuery').returns(QUERY);
-    getState = spy();
-    Categories.prototype.flux = <any>{ store: { getState } };
+    //selectAutocompleteQuery = stub(Selectors, 'autocompleteQuery').returns(QUERY);
+    select = Categories.prototype.select = spy(() => QUERY);
+    Categories.prototype.flux = <any>{};
     categories = new Categories();
   });
   afterEach(() => delete Categories.prototype.flux);
@@ -30,7 +29,7 @@ suite('Categories', ({ expect, spy, stub }) => {
           const updateSearch = spy(() => action);
           const handler = categories.state.onClick({ value });
 
-          selectAutocompleteQuery.returns(query);
+          select = Categories.prototype.select = spy(() => query);
           categories.$autocomplete = <any>{ category: navigationId };
           categories.actions = <any>{ updateSearch };
           categories.flux = <any>{ store: { getState: () => state } };
@@ -38,7 +37,7 @@ suite('Categories', ({ expect, spy, stub }) => {
           handler();
 
           expect(updateSearch).to.be.calledWith({ navigationId, value, query, clear: true });
-          expect(selectAutocompleteQuery).to.be.calledWith(state);
+          expect(select).to.be.calledWith(Selectors.autocompleteQuery);
         });
       });
 

--- a/test/unit/categories.ts
+++ b/test/unit/categories.ts
@@ -10,7 +10,6 @@ suite('Categories', ({ expect, spy, stub }) => {
   let select: sinon.SinonSpy;
 
   beforeEach(() => {
-    //selectAutocompleteQuery = stub(Selectors, 'autocompleteQuery').returns(QUERY);
     select = Categories.prototype.select = spy(() => QUERY);
     Categories.prototype.flux = <any>{};
     categories = new Categories();

--- a/test/unit/categories.ts
+++ b/test/unit/categories.ts
@@ -7,10 +7,10 @@ const QUERY = 'red dress';
 
 suite('Categories', ({ expect, spy, stub }) => {
   let categories: Categories;
-  let select: sinon.SinonSpy;
+  let select: sinon.SinonStub;
 
   beforeEach(() => {
-    select = Categories.prototype.select = spy(() => QUERY);
+    select = Categories.prototype.select = stub().returns(QUERY);
     Categories.prototype.flux = <any>{};
     categories = new Categories();
   });
@@ -28,7 +28,7 @@ suite('Categories', ({ expect, spy, stub }) => {
           const updateSearch = spy(() => action);
           const handler = categories.state.onClick({ value });
 
-          select = Categories.prototype.select = spy(() => query);
+          select.returns(query);
           categories.$autocomplete = <any>{ category: navigationId };
           categories.actions = <any>{ updateSearch };
           categories.flux = <any>{ store: { getState: () => state } };

--- a/test/unit/sayt.ts
+++ b/test/unit/sayt.ts
@@ -170,7 +170,7 @@ suite('Sayt', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias })
   describe('setInactive()', () => {
     it('should call unregisterClickAwayHandler()', () => {
       const unregisterClickAwayHandler = sayt.unregisterClickAwayHandler = spy();
-      sayt.select = spy(() => undefined);
+      sayt.select = spy();
       sayt.set = () => null;
       sayt.flux = <any>{ emit: () => null};
 

--- a/test/unit/sayt.ts
+++ b/test/unit/sayt.ts
@@ -27,20 +27,17 @@ suite('Sayt', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias })
       describe('highlight()', () => {
         it('should replace the current autocomplete query', () => {
           const query = 'yellow tie';
-          const state = { a: 'b' };
-          const autocompleteQuerySelector = stub(Selectors, 'autocompleteQuery').returns(query);
-          sayt.flux = <any>{ store: { getState: () => state } };
+          const select = sayt.select = spy(() => query);
 
           const highlighted = sayt.state.highlight('flamboyant yellow tie', '<i>$&</i>');
 
           expect(highlighted).to.eq('flamboyant <i>yellow tie</i>');
-          expect(autocompleteQuerySelector).to.be.calledWith(state);
+          expect(select).to.be.calledWith(Selectors.autocompleteQuery);
         });
 
         it('should be case insensitive', () => {
           const query = 'YelLoW tIE';
-          stub(Selectors, 'autocompleteQuery').returns(query);
-          sayt.flux = <any>{ store: { getState: () => null } };
+          sayt.select = spy(() => query);
 
           const highlighted = sayt.state.highlight('flamboyant YElLOw Tie', '<p>$&</p>');
 
@@ -173,9 +170,9 @@ suite('Sayt', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias })
   describe('setInactive()', () => {
     it('should call unregisterClickAwayHandler()', () => {
       const unregisterClickAwayHandler = sayt.unregisterClickAwayHandler = spy();
-      stub(Selectors, 'query');
+      sayt.select = spy(() => undefined);
       sayt.set = () => null;
-      sayt.flux = <any>{ emit: () => null, store: { getState: () => null } };
+      sayt.flux = <any>{ emit: () => null};
 
       sayt.setInactive();
 
@@ -187,8 +184,8 @@ suite('Sayt', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias })
       const state = { a: 'b' };
       const emit = spy();
       const set = sayt.set = spy();
-      const querySelector = stub(Selectors, 'query').returns(query);
-      sayt.flux = <any>{ emit, store: { getState: () => state } };
+      const select = sayt.select = spy(() => query);
+      sayt.flux = <any>{ emit };
       sayt.unregisterClickAwayHandler = () => null;
       sayt.state.isActive = true;
 
@@ -196,7 +193,7 @@ suite('Sayt', ({ expect, spy, stub, itShouldBeConfigurable, itShouldHaveAlias })
 
       expect(set).to.be.calledWith({ isActive: false });
       expect(emit).to.be.calledWithExactly('query:update', query);
-      expect(querySelector).to.be.calledWith(state);
+      expect(select).to.be.calledWith(Selectors.query);
     });
 
     it('should not set isActive if not already active', () => {


### PR DESCRIPTION
The BBD-799 PRs:
* https://github.com/groupby/storefront-collections/pull/16
* https://github.com/groupby/storefront-navigation/pull/31
* https://github.com/groupby/storefront-page-size/pull/15
* https://github.com/groupby/storefront-query/pull/27
* https://github.com/groupby/storefront-recommendations/pull/7
* https://github.com/groupby/storefront-record-count/pull/18
* https://github.com/groupby/storefront-sayt/pull/34
* https://github.com/groupby/storefront-sort/pull/17
* https://github.com/groupby/storefront-structure/pull/37
* https://github.com/groupby/storefront-breadcrumbs/pull/20
