### PR TITLE
fix(BBD-846): search box doesn't capture value when selecting refinement suggestion in autocomplete

### DIFF
--- a/src/refinements/index.html
+++ b/src/refinements/index.html
@@ -1,6 +1,6 @@
 <h4>{ $navigation.label }</h4>
 <gb-list items="{ $navigation.refinements }" item-alias="refinement">
-  <gb-link class="gb-autocomplete-target" data-query="" data-field="{ $navigation.field }" data-refinement="{ $refinement }" onmouseenter="{ $autocomplete.onHover }" on-click="{ $navigations.onClick($navigation.field, $refinement) }">
+  <gb-link class="gb-autocomplete-target" data-query="{ $refinement }" data-field="{ $navigation.field }" data-refinement="{ $refinement }" onmouseenter="{ $autocomplete.onHover }" on-click="{ $navigations.onClick($navigation.field, $refinement) }">
     <yield>
       <gb-raw content="{ $sayt.highlight($refinement, '<b>$&</b>') }"></gb-raw>
     </yield>


### PR DESCRIPTION
The problem was for refinement in sayt data-query was assigned to empty string, which resulted in no value in the search box.

Please review along with e2e test in preset: https://github.com/groupby/storefront-presets/pull/45