### PR TITLE
fix(BBD-790): when there are still products in sayt, don't close sayt

### DIFF
--- a/src/autocomplete/index.ts
+++ b/src/autocomplete/index.ts
@@ -74,7 +74,7 @@ class Autocomplete {
     if (this.isActive() && this.isMounted) {
       this.setActivation(this.activationTargets(), this.state.selected, false);
     }
-    this.set({ suggestions, navigations, categoryValues, selected: -1 });
+    this.set({ suggestions, navigations, categoryValues, products, selected: -1 });
     if (suggestions.length + navigations.length + categoryValues.length + products.length === 0) {
       this.flux.emit('sayt:hide');
     } else {

--- a/src/autocomplete/index.ts
+++ b/src/autocomplete/index.ts
@@ -75,7 +75,6 @@ class Autocomplete {
       this.setActivation(this.activationTargets(), this.state.selected, false);
     }
     this.set({ suggestions, navigations, categoryValues, selected: -1 });
-    console.log('products', [...products])
     if (suggestions.length + navigations.length + categoryValues.length + products.length === 0) {
       this.flux.emit('sayt:hide');
     } else {
@@ -121,8 +120,7 @@ namespace Autocomplete {
     categoryValues: string[];
     suggestions: Store.Autocomplete.Suggestion[];
     navigations: Store.Autocomplete.Navigation[];
-    //TODO
-    products: Store.Autocomplete.Product[];
+    products: Store.ProductWithMetadata[];
     onHover(event: MouseEvent): void;
   }
 }

--- a/src/autocomplete/index.ts
+++ b/src/autocomplete/index.ts
@@ -17,10 +17,11 @@ class Autocomplete {
 
   constructor() {
     const suggestions = this.select(Selectors.autocompleteSuggestions);
+    const products = this.select(Selectors.autocompleteProducts);
     const category = this.select(Selectors.autocompleteCategoryField);
     const categoryValues = this.select(Selectors.autocompleteCategoryValues);
     const navigations = this.select(Selectors.autocompleteNavigations);
-    this.state = { ...this.state, suggestions, navigations, category, categoryValues, selected: -1 };
+    this.state = { ...this.state, suggestions, navigations, category, categoryValues, products, selected: -1 };
   }
 
   init() {
@@ -68,12 +69,14 @@ class Autocomplete {
     }
   }
 
-  updateSuggestions = ({ suggestions, navigations, category: { values: categoryValues } }: Store.Autocomplete) => {
+  // tslint:disable-next-line:max-line-length
+  updateSuggestions = ({ suggestions, navigations, category: { values: categoryValues }, products }: Store.Autocomplete) => {
     if (this.isActive() && this.isMounted) {
       this.setActivation(this.activationTargets(), this.state.selected, false);
     }
     this.set({ suggestions, navigations, categoryValues, selected: -1 });
-    if (suggestions.length + navigations.length + categoryValues.length === 0) {
+    console.log('products', [...products])
+    if (suggestions.length + navigations.length + categoryValues.length + products.length === 0) {
       this.flux.emit('sayt:hide');
     } else {
       this.flux.emit('sayt:show');
@@ -118,6 +121,8 @@ namespace Autocomplete {
     categoryValues: string[];
     suggestions: Store.Autocomplete.Suggestion[];
     navigations: Store.Autocomplete.Navigation[];
+    //TODO
+    products: Store.Autocomplete.Product[];
     onHover(event: MouseEvent): void;
   }
 }

--- a/test/unit/autocomplete.ts
+++ b/test/unit/autocomplete.ts
@@ -199,6 +199,7 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
       autocomplete.setActivation = () => expect.fail();
 
       autocomplete.updateSuggestions(<any>{ suggestions, navigations, category: { values: categoryValues }, products });
+
       expect(set).to.be.calledWith({ suggestions, navigations, categoryValues, products, selected: -1 });
     });
 

--- a/test/unit/autocomplete.ts
+++ b/test/unit/autocomplete.ts
@@ -7,6 +7,7 @@ const CATEGORY = 'brand';
 const CATEGORY_VALUES = ['a', 'b', 'c'];
 const SUGGESTIONS = ['d', 'e', 'f'];
 const NAVIGATIONS = ['g', 'h', 'i'];
+const PRODUCTS = ['j', 'k', 'l', 'm'];
 
 suite('Autocomplete', ({ expect, spy, stub }) => {
   let autocomplete: Autocomplete;
@@ -19,6 +20,7 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
     select.withArgs(Selectors.autocompleteCategoryField).returns(CATEGORY);
     select.withArgs(Selectors.autocompleteCategoryValues).returns(CATEGORY_VALUES);
     select.withArgs(Selectors.autocompleteNavigations).returns(NAVIGATIONS);
+    select.withArgs(Selectors.autocompleteProducts).returns(PRODUCTS);
     autocomplete = new Autocomplete();
   });
   afterEach(() => {
@@ -35,7 +37,8 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
           category: CATEGORY,
           categoryValues: CATEGORY_VALUES,
           suggestions: SUGGESTIONS,
-          navigations: NAVIGATIONS
+          navigations: NAVIGATIONS,
+          products: PRODUCTS
         });
       });
     });
@@ -187,6 +190,7 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
     const suggestions = ['1', '2', '3'];
     const navigations = ['4', '5', '6'];
     const categoryValues = ['7', '8', '9'];
+    const products = ['10', '11'];
 
     it('should set values and not change activation', () => {
       const set = autocomplete.set = spy();
@@ -194,9 +198,8 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
       autocomplete.isActive = () => false;
       autocomplete.setActivation = () => expect.fail();
 
-      autocomplete.updateSuggestions(<any>{ suggestions, navigations, category: { values: categoryValues } });
-
-      expect(set).to.be.calledWith({ suggestions, navigations, categoryValues, selected: -1 });
+      autocomplete.updateSuggestions(<any>{ suggestions, navigations, category: { values: categoryValues }, products });
+      expect(set).to.be.calledWith({ suggestions, navigations, categoryValues, products, selected: -1 });
     });
 
     it('should not change activation if not mounted', () => {
@@ -206,7 +209,7 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
       autocomplete.isMounted = false;
       autocomplete.setActivation = () => expect.fail();
 
-      autocomplete.updateSuggestions(<any>{ suggestions, navigations, category: { values: categoryValues } });
+      autocomplete.updateSuggestions(<any>{ suggestions, navigations, category: { values: categoryValues }, products });
     });
 
     it('should deactivate selected element', () => {
@@ -220,28 +223,50 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
       autocomplete.isActive = () => true;
       autocomplete.isMounted = true;
 
-      autocomplete.updateSuggestions(<any>{ suggestions, navigations, category: { values: categoryValues } });
+      autocomplete.updateSuggestions(<any>{ suggestions, navigations, category: { values: categoryValues }, products });
 
-      expect(set).to.be.calledWith({ suggestions, navigations, categoryValues, selected: -1 });
+      expect(set).to.be.calledWith({ suggestions, navigations, categoryValues, products, selected: -1 });
       expect(setActivation).to.be.calledWith(targets, selected, false);
     });
 
-    it('should inactivate sayt when there are no suggestions', () => {
+    it('should inactivate sayt when there are no suggestions nor products', () => {
       const emit = spy();
       autocomplete.flux = <any>{ emit };
       autocomplete.set = () => null;
 
-      autocomplete.updateSuggestions(<any>{ suggestions: [], navigations: [], category: { values: [] } });
+      autocomplete.updateSuggestions(<any>{ suggestions: [], navigations: [], products: [], category: { values: [] } });
 
       expect(emit).to.be.calledWith('sayt:hide');
     });
 
-    it('should activate sayt when there are suggestions', () => {
+    it('should activate sayt when there are suggestions and no products', () => {
       const emit = spy();
       autocomplete.flux = <any>{ emit };
       autocomplete.set = () => null;
 
-      autocomplete.updateSuggestions(<any>{ suggestions, navigations, category: { values: categoryValues } });
+      // tslint:disable-next-line:max-line-length
+      autocomplete.updateSuggestions(<any>{ suggestions, navigations, products: [], category: { values: categoryValues } });
+
+      expect(emit).to.be.calledWith('sayt:show');
+    });
+
+    it('should activate sayt when there are only products and no suggestions', () => {
+      const emit = spy();
+      autocomplete.flux = <any>{ emit };
+      autocomplete.set = () => null;
+
+      autocomplete.updateSuggestions(<any>{ suggestions: [], navigations: [], products, category: { values: [] } });
+
+      expect(emit).to.be.calledWith('sayt:show');
+    });
+
+    it('should activate sayt when there are both products and suggestions', () => {
+      const emit = spy();
+      autocomplete.flux = <any>{ emit };
+      autocomplete.set = () => null;
+
+      // tslint:disable-next-line:max-line-length
+      autocomplete.updateSuggestions(<any>{ suggestions, navigations, products: [], category: { values: categoryValues } });
 
       expect(emit).to.be.calledWith('sayt:show');
     });
@@ -320,7 +345,7 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
       const saytProducts = spy();
       const state = { a: 'b' };
       select.returns(query);
-      autocomplete.flux = <any>{ emit: () => null, saytProducts};
+      autocomplete.flux = <any>{ emit: () => null, saytProducts };
 
       autocomplete.updateProducts(<any>{ dataset: {} });
 

--- a/test/unit/autocomplete.ts
+++ b/test/unit/autocomplete.ts
@@ -244,8 +244,9 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
       autocomplete.flux = <any>{ emit };
       autocomplete.set = () => null;
 
-      // tslint:disable-next-line:max-line-length
-      autocomplete.updateSuggestions(<any>{ suggestions, navigations, products: [], category: { values: categoryValues } });
+      autocomplete.updateSuggestions(
+        <any>{ suggestions, navigations, products: [], category: { values: categoryValues } }
+      );
 
       expect(emit).to.be.calledWith('sayt:show');
     });
@@ -265,8 +266,9 @@ suite('Autocomplete', ({ expect, spy, stub }) => {
       autocomplete.flux = <any>{ emit };
       autocomplete.set = () => null;
 
-      // tslint:disable-next-line:max-line-length
-      autocomplete.updateSuggestions(<any>{ suggestions, navigations, products: [], category: { values: categoryValues } });
+      autocomplete.updateSuggestions(
+        <any>{ suggestions, navigations, products: [], category: { values: categoryValues } }
+      );
 
       expect(emit).to.be.calledWith('sayt:show');
     });


### PR DESCRIPTION
Before autocomplete dropdown will be closed if there are products but no suggestions.
Request from Kent that we should leave dropdown open if it is the case.